### PR TITLE
Adds the ability to update ACEs when username changes

### DIFF
--- a/Security/Acl/MutableAclProvider.php
+++ b/Security/Acl/MutableAclProvider.php
@@ -310,6 +310,39 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
         $this->propertyChanges->offsetSet($sender, $propertyChanges);
     }
 
+    /**
+     * Updates a user security identity when the user's username changes
+     *
+     * @param UserSecurityIdentity $usid
+     * @param string $oldUsername
+     */
+    public function updateUserSecurityIdentity(UserSecurityIdentity $usid, $oldUsername)
+    {
+        $this->connection->selectCollection($this->options['entry_collection'])
+                         ->createQueryBuilder()
+                         ->update()
+                         ->multiple(true)
+                         ->field('securityIdentity.username')->set($usid->getUsername())
+                         ->field('securityIdentity.username')->equals($oldUsername)
+                         ->getQuery()
+                         ->execute();
+    }
+
+    /**
+     * Deletes all ACEs for a given UserSecurityIdentity
+     *
+     * @param UserSecurityIdentity $usid
+     */
+    public function deleteAceBySecurityIdentity(UserSecurityIdentity $usid)
+    {
+        $this->connection->selectCollection($this->options['entry_collection'])
+                         ->createQueryBuilder()
+                         ->remove()
+                         ->field('securityIdentity.username')->equals($usid->getUsername())
+                         ->getQuery()
+                         ->execute();
+    }
+
 
     /**
      * Creates the ACL for the passed object identity


### PR DESCRIPTION
This commit adds an updateUserSecurityIdentity method, which is needed when a user updates their username. In my case, the username is just an alias to an email address, so this was necessary if the user happens to update their email address. See this issue: https://github.com/symfony/symfony/issues/5787 as well as this commit: https://github.com/symfony/symfony/commit/8d39213f4cca19466f84a5656a199eee98602ab1

A deleteAceBySecurityIdentity was also added. This allows you to pass in a UserSecurityIdentity object and delete all ACEs associated with it. This is useful when editing a user's permissions via checkboxes, for example, and being able to simply delete all their ACEs and recreate them on edit.
