### PR TITLE
make sure we are selecting records based on existing oid records.

### DIFF
--- a/Security/Acl/AclProvider.php
+++ b/Security/Acl/AclProvider.php
@@ -72,6 +72,10 @@ class AclProvider implements AclProviderInterface
     {
         $parentId = $this->retrieveObjectIdentityPrimaryKey($parentOid);
 
+        if (is_null($parentId)) {
+            return array();
+        };
+
         if ($directChildrenOnly) {
             $query = array(
                 "parent" => $parentId,

--- a/Security/Acl/AclProvider.php
+++ b/Security/Acl/AclProvider.php
@@ -78,7 +78,7 @@ class AclProvider implements AclProviderInterface
 
         if ($directChildrenOnly) {
             $query = array(
-                "parent" => $parentId,
+                "parent._id" => $parentId,
             );
         } else {
             $query = array(

--- a/Tests/Security/Acl/AclProviderTest.php
+++ b/Tests/Security/Acl/AclProviderTest.php
@@ -115,6 +115,45 @@ class AclProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('SomeClass', $sid->getClass());
     }
 
+    public function testFindChildren()
+    {
+        $oid = new ObjectIdentity('123', 'Bundle\SomeVendor\MyBundle\Entity\SomeEntity');
+        $provider = $this->getProvider();
+
+        $oids = $provider->findChildren($oid);
+
+        $this->assertTrue(is_array($oids), 'check return value is array');
+        $this->assertCount(4, $oids, 'check return value is zero length');
+        foreach ($oids as $oid) {
+            $this->assertTrue(in_array($this->oids[1]['_id'], $oid['ancestors']), 'check oid has correct ancestor');
+        }
+    }
+
+    public function testFindDirectChildren()
+    {
+        $oid = new ObjectIdentity('123', 'Bundle\SomeVendor\MyBundle\Entity\SomeEntity');
+        $provider = $this->getProvider();
+
+        $oids = $provider->findChildren($oid, true);
+
+        $this->assertTrue(is_array($oids), 'check return value is array');
+        $this->assertCount(2, $oids, 'check return value is zero length');
+        foreach ($oids as $oid) {
+            $this->assertTrue(in_array($this->oids[1]['_id'], $oid['ancestors']), 'check oid has correct ancestor');
+        }
+    }
+
+    public function testNotFindChildren()
+    {
+        $oid = new ObjectIdentity('9999', 'foo');
+        $provider = $this->getProvider();
+
+        $oids = $provider->findChildren($oid);
+
+        $this->assertTrue(is_array($oids), 'check return value is array');
+        $this->assertCount(0, $oids, 'check return value is zero length');
+    }
+
     protected function setUp()
     {
         if (!class_exists('Doctrine\MongoDB\Connection')) {


### PR DESCRIPTION
When trying to find children for an Acl that doesn't exist it would return all Oids.
This commit just returns an empty array when the oid is not found.