### PR TITLE
Fixed AclProvider, fixed mongodb 2.6+ issue

### DIFF
--- a/Security/Acl/AclProvider.php
+++ b/Security/Acl/AclProvider.php
@@ -228,7 +228,7 @@ class AclProvider implements AclProviderInterface
         }
 
         list($oids, $types) = $this->getOidTypeSet($objIdentities, $sids);
-        $entryQuery = array('$or' => array(array('objectIdentity.$id' => array('$in' => $oids)), array('class' => array('$in' => $types))));
+        $entryQuery = array('$or' => array(array('objectIdentity.$id' => array('$in' => $oids)), array('class' => array('$in' => array_values($types)))));
         $entryCursor = $this->connection->selectCollection($this->options['entry_collection'])->find($entryQuery);
         $oidQuery = array('_id' => array('$in' => $oids));
         $oidCursor = $this->connection->selectCollection($this->options['oid_collection'])->find($oidQuery);


### PR DESCRIPTION
In mongoDB 2.6+ the $in param can result in the following error;
mongodb Can't canonicalize query: BadValue $in needs an array

At the $entryQuery this occured when adding multiple types in the query.

The fix is simple, start using array_values for $types.